### PR TITLE
application-oauth 설정파일 추가

### DIFF
--- a/src/main/resources/application-oauth.properties
+++ b/src/main/resources/application-oauth.properties
@@ -1,0 +1,3 @@
+spring.security.oauth2.client.registration.google.client-id=[구글에서 발급받은 클라이언트 ID]
+spring.security.oauth2.client.registration.google.client-secret=[구글에서 발급받은 클라이언트 비밀번호]
+spring.security.oauth2.client.registration.google.scope=profile,email


### PR DESCRIPTION
교재 173 Page에서 발급받은 구글 클라이언트 ID/PW를 세팅하는 설정파일이 누락되어 있었습니다.
